### PR TITLE
🔇 Removed info logging of renamed files

### DIFF
--- a/.changeset/early-peas-prove.md
+++ b/.changeset/early-peas-prove.md
@@ -1,0 +1,5 @@
+---
+'@2digits/cli': patch
+---
+
+Fixed info logs back to debug logs

--- a/packages/cli/src/utils/rename.ts
+++ b/packages/cli/src/utils/rename.ts
@@ -10,7 +10,7 @@ export async function renamePlaceholders(path: string) {
 
   for await (const placeholder of placeholders) {
     const renamed = placeholder.toString().replace(/_2d_/g, '');
-    consola.info(placeholder, renamed);
+    consola.debug(placeholder, renamed);
 
     await fs.rename(placeholder, renamed);
   }


### PR DESCRIPTION
- 🔇 Removed info logging of renamed files
- docs(changeset): Fixed info logs back to debug logs
